### PR TITLE
allow TLS connection with client-side pass auth

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -31,6 +31,7 @@ type Configuration struct {
 	METADATA_DB_HOST        string
 	METADATA_DB_PORT        string
 	METADATA_DB_TLS_ENABLED bool
+	METADATA_DB_TLS_MUTUAL  bool
 	METADATA_DB_TLS_KEY     string
 	METADATA_DB_TLS_CRT     string
 	METADATA_DB_TLS_CA      string

--- a/db/db.go
+++ b/db/db.go
@@ -302,7 +302,11 @@ func InitalizeMetadataDbConnection(l logger) (MetadataStorage, error) {
 	metadataDbPort := configuration.METADATA_DB_PORT
 	var metadataDbUrl string
 	if configuration.METADATA_DB_TLS_ENABLED {
-		metadataDbUrl = "postgres://" + metadataDbUser + "@" + metadataDbHost + ":" + metadataDbPort + "/" + metadataDbName + "?sslmode=verify-full"
+		metadataAuth := ""
+		if !configuration.METADATA_DB_TLS_MUTUAL {
+			metadataAuth = ":" + metadataDbPassword
+		}
+		metadataDbUrl = "postgres://" + metadataDbUser + metadataAuth + "@" + metadataDbHost + ":" + metadataDbPort + "/" + metadataDbName + "?sslmode=verify-full"
 	} else {
 		metadataDbUrl = "postgres://" + metadataDbUser + ":" + metadataDbPassword + "@" + metadataDbHost + ":" + metadataDbPort + "/" + metadataDbName + "?sslmode=disable"
 	}
@@ -314,11 +318,6 @@ func InitalizeMetadataDbConnection(l logger) (MetadataStorage, error) {
 	config.MaxConns = 5
 
 	if configuration.METADATA_DB_TLS_ENABLED {
-		cert, err := tls.LoadX509KeyPair(configuration.METADATA_DB_TLS_CRT, configuration.METADATA_DB_TLS_KEY)
-		if err != nil {
-			return MetadataStorage{}, err
-		}
-
 		CACert, err := os.ReadFile(configuration.METADATA_DB_TLS_CA)
 		if err != nil {
 			return MetadataStorage{}, err
@@ -326,7 +325,17 @@ func InitalizeMetadataDbConnection(l logger) (MetadataStorage, error) {
 
 		CACertPool := x509.NewCertPool()
 		CACertPool.AppendCertsFromPEM(CACert)
-		config.ConnConfig.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: CACertPool, InsecureSkipVerify: true}
+
+		if configuration.METADATA_DB_TLS_MUTUAL {
+			cert, err := tls.LoadX509KeyPair(configuration.METADATA_DB_TLS_CRT, configuration.METADATA_DB_TLS_KEY)
+			if err != nil {
+				return MetadataStorage{}, err
+			}
+
+			config.ConnConfig.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: CACertPool, InsecureSkipVerify: true}
+		} else {
+			config.ConnConfig.TLSConfig = &tls.Config{RootCAs: CACertPool, InsecureSkipVerify: true}
+		}
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)


### PR DESCRIPTION
## Why?

Amazon RDS (Postgres) does not seem to support mutual TLS but `memphis` forces mutual TLS when `METADATA_DB_TLS_ENABLED` is enabled. This makes it impossible to use RDS as metadata store for `memphis`

## Changes in this PR

- add `METADATA_DB_TLS_MUTUAL` env variable (boolean)
- modify `InitalizeMetadataDbConnection` in [db.go](https://github.com/memphisdev/memphis/blob/379065b3352d065def676a6451b4e86dc2b6b600/db/db.go#L294) to still set `sslmode=verify-full` on the connection string but not attempt to load a client cert when `METADATA_DB_TLS_ENABLED` is true but `METADATA_DB_TLS_MUTUAL` is false