### PR TITLE
replace numberWithCommas with toLocaleString

### DIFF
--- a/ui_src/src/components/Tabs/index.js
+++ b/ui_src/src/components/Tabs/index.js
@@ -44,7 +44,7 @@ const CustomTabs = ({ tabs, onChange, value, disabled, length, tooltip, icon = f
                                         </div>
                                     </div>
                                 )}
-                                {length && length[index] && !icon && <label className="dls-size"> {length[index]}</label>}
+                                {length && length[index] && !icon && <label className="dls-size"> {length[index].toLocaleString()}</label>}
                             </label>
                         )
                     };

--- a/ui_src/src/domain/messageJourney/index.js
+++ b/ui_src/src/domain/messageJourney/index.js
@@ -16,7 +16,7 @@ import React, { useEffect, useContext, useState } from 'react';
 import { StringCodec, JSONCodec } from 'nats.ws';
 import { useHistory } from 'react-router-dom';
 
-import { convertBytes, numberWithCommas, parsingDate } from '../../services/valueConvertor';
+import { convertBytes, parsingDate } from '../../services/valueConvertor';
 import PoisonMessage from './components/poisonMessage';
 import { ApiEndpoints } from '../../const/apiEndpoints';
 import BackIcon from '../../assets/images/backIcon.svg';
@@ -157,19 +157,19 @@ const MessageJourney = () => {
                     details: [
                         {
                             name: 'Unacked messages',
-                            value: numberWithCommas(row?.total_poison_messages)
+                            value: row?.total_poison_messages?.toLocaleString()
                         },
                         {
                             name: 'Unprocessed messages',
-                            value: numberWithCommas(row?.unprocessed_messages)
+                            value: row?.unprocessed_messages?.toLocaleString()
                         },
                         {
                             name: 'In process message',
-                            value: numberWithCommas(row?.in_process_messages)
+                            value: row?.in_process_messages?.toLocaleString()
                         },
                         {
                             name: 'Max ack time',
-                            value: `${numberWithCommas(row?.max_ack_time_ms)}ms`
+                            value: `${row?.max_ack_time_ms?.toLocaleString()}ms`
                         },
                         {
                             name: 'Max message deliveries',
@@ -187,19 +187,19 @@ const MessageJourney = () => {
                         cgData: [
                             {
                                 name: 'Unacked messages',
-                                value: numberWithCommas(row.total_poison_messages)
+                                value: row.total_poison_messages?.toLocaleString()
                             },
                             {
                                 name: 'Unprocessed messages',
-                                value: numberWithCommas(row.unprocessed_messages)
+                                value: row.unprocessed_messages?.toLocaleString()
                             },
                             {
                                 name: 'In process message',
-                                value: numberWithCommas(row.in_process_messages)
+                                value: row.in_process_messages?.toLocaleString()
                             },
                             {
                                 name: 'Max ack time',
-                                value: `${numberWithCommas(row.max_ack_time_ms)}ms`
+                                value: `${row.max_ack_time_ms?.toLocaleString()}ms`
                             },
                             {
                                 name: 'Max message deliveries',

--- a/ui_src/src/domain/overview/failedStations/index.js
+++ b/ui_src/src/domain/overview/failedStations/index.js
@@ -18,7 +18,7 @@ import { KeyboardArrowRightRounded } from '@material-ui/icons';
 import Lottie from 'lottie-react';
 
 import noActiveAndUnhealthy from '../../../assets/lotties/noActiveAndUnhealthy.json';
-import { numberWithCommas, parsingDate } from '../../../services/valueConvertor';
+import { parsingDate } from '../../../services/valueConvertor';
 import noActiveAndHealthy from '../../../assets/lotties/noActiveAndHealthy.json';
 import activeAndUnhealthy from '../../../assets/lotties/activeAndUnhealthy.json';
 import activeAndHealthy from '../../../assets/lotties/activeAndHealthy.json';
@@ -66,8 +66,8 @@ const FailedStations = ({ createStationTrigger }) => {
                                             <OverflowTip className="station-creation" text={parsingDate(station.created_at)}>
                                                 {parsingDate(station.created_at)}
                                             </OverflowTip>
-                                            <OverflowTip className="station-details total" text={numberWithCommas(station.total_messages)}>
-                                                <span className="centered">{numberWithCommas(station.total_messages)}</span>
+                                            <OverflowTip className="station-details total" text={station.total_messages?.toLocaleString()}>
+                                                <span className="centered">{station.total_messages?.toLocaleString()}</span>
                                             </OverflowTip>
                                             <div className="centered lottie">
                                                 {station?.has_dls_messages ? (

--- a/ui_src/src/domain/overview/genericDetails/index.js
+++ b/ui_src/src/domain/overview/genericDetails/index.js
@@ -14,7 +14,6 @@ import './style.scss';
 
 import React, { useContext } from 'react';
 import { Context } from '../../../hooks/store';
-import { numberWithCommas } from '../../../services/valueConvertor';
 import TotalMsg from '../../../assets/images/TotalMessages.svg';
 import TotalPoison from '../../../assets/images/DeadLetteredMessages.svg';
 import TotalStations from '../../../assets/images/TotalStations.svg';
@@ -30,7 +29,7 @@ const GenericDetails = () => {
                     <img src={TotalStations} width={50} height={50} alt="Total stations" className="icon-wrapper" />
                     <div className="data-wrapper">
                         <span>Stations</span>
-                        <p>{numberWithCommas(state?.monitor_data?.total_stations)}</p>
+                        <p>{state?.monitor_data?.total_stations?.toLocaleString()}</p>
                     </div>
                 </div>
                 <Divider type="vertical" />
@@ -38,7 +37,7 @@ const GenericDetails = () => {
                     <img src={TotalMsg} width={50} height={50} alt="Total stations" className="icon-wrapper" />
                     <div className="data-wrapper">
                         <span>Messages</span>
-                        <p>{numberWithCommas(state?.monitor_data?.total_messages)}</p>
+                        <p>{state?.monitor_data?.total_messages?.toLocaleString()}</p>
                     </div>
                 </div>
                 <Divider type="vertical" />
@@ -46,7 +45,7 @@ const GenericDetails = () => {
                     <img src={TotalPoison} width={50} height={50} alt="Total stations" className="icon-wrapper" />
                     <div className="data-wrapper">
                         <span>Dead-letter messages</span>
-                        <p>{numberWithCommas(state?.monitor_data?.total_dls_messages)}</p>
+                        <p>{state?.monitor_data?.total_dls_messages?.toLocaleString()}</p>
                     </div>
                 </div>
             </div>

--- a/ui_src/src/domain/stationOverview/stationObservabilty/ProduceConsumList/index.js
+++ b/ui_src/src/domain/stationOverview/stationObservabilty/ProduceConsumList/index.js
@@ -18,7 +18,6 @@ import { Virtuoso } from 'react-virtuoso';
 
 import waitingProducer from '../../../../assets/images/waitingProducer.svg';
 import waitingConsumer from '../../../../assets/images/waitingConsumer.svg';
-import { numberWithCommas } from '../../../../services/valueConvertor';
 import OverflowTip from '../../../../components/tooltip/overflowtip';
 import unsupported from '../../../../assets/images/unsupported.svg';
 import StatusIndication from '../../../../components/indication';
@@ -130,19 +129,19 @@ const ProduceConsumList = ({ producer }) => {
                 details: [
                     {
                         name: 'Unacked messages',
-                        value: numberWithCommas(cgsList[rowIndex]?.poison_messages)
+                        value: cgsList[rowIndex]?.poison_messages?.toLocaleString()
                     },
                     {
                         name: 'Unprocessed messages',
-                        value: numberWithCommas(cgsList[rowIndex]?.unprocessed_messages)
+                        value: cgsList[rowIndex]?.unprocessed_messages?.toLocaleString()
                     },
                     {
                         name: 'In process message',
-                        value: numberWithCommas(cgsList[rowIndex]?.in_process_messages)
+                        value: cgsList[rowIndex]?.in_process_messages?.toLocaleString()
                     },
                     {
                         name: 'Max ack time',
-                        value: `${numberWithCommas(cgsList[rowIndex]?.max_ack_time_ms)}ms`
+                        value: `${cgsList[rowIndex]?.max_ack_time_ms?.toLocaleString()}ms`
                     },
                     {
                         name: 'Max message deliveries',
@@ -229,15 +228,15 @@ const ProduceConsumList = ({ producer }) => {
                                                 {row.name}
                                             </OverflowTip>
                                             <OverflowTip
-                                                text={row.poison_messages}
+                                                text={row.poison_messages.toLocaleString()}
                                                 width={'80px'}
                                                 textAlign={'center'}
                                                 textColor={row.poison_messages > 0 ? '#F7685B' : null}
                                             >
-                                                {row.poison_messages}
+                                                {row.poison_messages.toLocaleString()}
                                             </OverflowTip>
-                                            <OverflowTip text={row.unprocessed_messages} width={'80px'} textAlign={'center'}>
-                                                {row.unprocessed_messages}
+                                            <OverflowTip text={row.unprocessed_messages.toLocaleString()} width={'80px'} textAlign={'center'}>
+                                                {row.unprocessed_messages.toLocaleString()}
                                             </OverflowTip>
                                             <span className="status-icon" style={{ width: '35px' }}>
                                                 <StatusIndication is_active={row.is_active} is_deleted={row.is_deleted} />

--- a/ui_src/src/domain/stationOverview/stationObservabilty/components/messageDetails/index.js
+++ b/ui_src/src/domain/stationOverview/stationObservabilty/components/messageDetails/index.js
@@ -15,7 +15,7 @@ import { useHistory } from 'react-router-dom';
 import Lottie from 'lottie-react';
 import { Space } from 'antd';
 
-import { convertBytes, numberWithCommas, parsingDate } from '../../../../../services/valueConvertor';
+import { convertBytes, parsingDate } from '../../../../../services/valueConvertor';
 import attachedPlaceholder from '../../../../../assets/images/attachedPlaceholder.svg';
 import animationData from '../../../../../assets/lotties/MemphisGif.json';
 import { ApiEndpoints } from '../../../../../const/apiEndpoints';
@@ -75,19 +75,19 @@ const MessageDetails = ({ isDls, isFailedSchemaMessage = false }) => {
                     details: [
                         {
                             name: 'Unacked messages',
-                            value: numberWithCommas(row?.total_poison_messages)
+                            value: row?.total_poison_messages?.toLocaleString()
                         },
                         {
                             name: 'Unprocessed messages',
-                            value: numberWithCommas(row?.unprocessed_messages)
+                            value: row?.unprocessed_messages?.toLocaleString()
                         },
                         {
                             name: 'In process message',
-                            value: numberWithCommas(row?.in_process_messages)
+                            value: row?.in_process_messages?.toLocaleString()
                         },
                         {
                             name: 'Max ack time',
-                            value: `${numberWithCommas(row?.max_ack_time_ms)}ms`
+                            value: `${row?.max_ack_time_ms?.toLocaleString()}ms`
                         },
                         {
                             name: 'Max message deliveries',

--- a/ui_src/src/domain/stationOverview/stationObservabilty/messages/index.js
+++ b/ui_src/src/domain/stationOverview/stationObservabilty/messages/index.js
@@ -16,7 +16,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { InfoOutlined } from '@material-ui/icons';
 import { message } from 'antd';
 
-import { messageParser, msToUnits, numberWithCommas } from '../../../../services/valueConvertor';
+import { messageParser, msToUnits } from '../../../../services/valueConvertor';
 import deadLetterPlaceholder from '../../../../assets/images/deadLetterPlaceholder.svg';
 import waitingMessages from '../../../../assets/images/waitingMessages.svg';
 import idempotencyIcon from '../../../../assets/images/idempotencyIcon.svg';
@@ -230,10 +230,10 @@ const Messages = () => {
                 <div className="messages-amount">
                     <InfoOutlined />
                     <p>
-                        Showing last {numberWithCommas(amount)} out of{' '}
+                        Showing last {amount?.toLocaleString()} out of{' '}
                         {tabValue === tabs[0]
-                            ? numberWithCommas(stationState?.stationSocketData?.total_messages)
-                            : numberWithCommas(stationState?.stationSocketData?.total_dls_messages)}{' '}
+                            ? stationState?.stationSocketData?.total_messages?.toLocaleString()
+                            : stationState?.stationSocketData?.total_dls_messages?.toLocaleString()}{' '}
                         messages
                     </p>
                 </div>

--- a/ui_src/src/domain/stationOverview/stationOverviewHeader/index.js
+++ b/ui_src/src/domain/stationOverview/stationOverviewHeader/index.js
@@ -17,7 +17,7 @@ import { Add, FiberManualRecord, InfoOutlined } from '@material-ui/icons';
 import { useHistory } from 'react-router-dom';
 import { MinusOutlined } from '@ant-design/icons';
 
-import { convertBytes, convertSecondsToDate, numberWithCommas } from '../../../services/valueConvertor';
+import { convertBytes, convertSecondsToDate } from '../../../services/valueConvertor';
 import deleteWrapperIcon from '../../../assets/images/deleteWrapperIcon.svg';
 import purgeWrapperIcon from '../../../assets/images/purgeWrapperIcon.svg';
 import averageMesIcon from '../../../assets/images/averageMesIcon.svg';
@@ -64,10 +64,10 @@ const StationOverviewHeader = () => {
                 setRetentionValue(convertSecondsToDate(stationState?.stationMetaData?.retention_value));
                 break;
             case 'bytes':
-                setRetentionValue(`${numberWithCommas(stationState?.stationMetaData?.retention_value)} bytes`);
+                setRetentionValue(`${stationState?.stationMetaData?.retention_value?.toLocaleString()} bytes`);
                 break;
             case 'messages':
-                setRetentionValue(`${numberWithCommas(stationState?.stationMetaData?.retention_value)} messages`);
+                setRetentionValue(`${stationState?.stationMetaData?.retention_value?.toLocaleString()} messages`);
                 break;
             default:
                 break;
@@ -291,7 +291,7 @@ const StationOverviewHeader = () => {
                         </div>
                         <div className="more-details">
                             <p className="title">Total messages</p>
-                            <p className="number">{numberWithCommas(stationState?.stationSocketData?.total_messages) || 0}</p>
+                            <p className="number">{stationState?.stationSocketData?.total_messages?.toLocaleString() || 0}</p>
                         </div>
                     </div>
                     <div className="details-wrapper pointer">

--- a/ui_src/src/domain/stationsList/stationBoxOverview/index.js
+++ b/ui_src/src/domain/stationsList/stationBoxOverview/index.js
@@ -17,7 +17,7 @@ import { MinusOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import Lottie from 'lottie-react';
 
-import { convertSecondsToDate, numberWithCommas } from '../../../services/valueConvertor';
+import { convertSecondsToDate } from '../../../services/valueConvertor';
 import activeAndHealthy from '../../../assets/lotties/activeAndHealthy.json';
 import noActiveAndUnhealthy from '../../../assets/lotties/noActiveAndUnhealthy.json';
 import noActiveAndHealthy from '../../../assets/lotties/noActiveAndHealthy.json';
@@ -138,7 +138,7 @@ const StationBoxOverview = ({ station, handleCheckedClick, isCheck }) => {
                             </div>
 
                             <p className="data-info">
-                                {station.total_messages === 0 ? <MinusOutlined style={{ color: '#2E2C34' }} /> : numberWithCommas(station?.total_messages)}
+                                {station.total_messages === 0 ? <MinusOutlined style={{ color: '#2E2C34' }} /> : station?.total_messages?.toLocaleString()}
                             </p>
                         </div>
                         <div className="station-meta poison">

--- a/ui_src/src/services/valueConvertor.js
+++ b/ui_src/src/services/valueConvertor.js
@@ -137,12 +137,6 @@ export const convertBytes = (bytes, round) => {
     }
 };
 
-export const numberWithCommas = (x) => {
-    if (x) {
-        return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    } else return 0;
-};
-
 export const capitalizeFirst = (str) => {
     return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 };
@@ -222,34 +216,34 @@ export const msToUnits = (value) => {
     let parsing = 0;
     switch (true) {
         case value < second && value >= 100:
-            return `${numberWithCommas(value)} ms`;
+            return `${value?.toLocaleString()} ms`;
         case value >= second && value < minute:
             parsing = isFloat(value / second) ? Math.round((value / second + Number.EPSILON) * 100) / 100 : value / second;
             if (parsing === 1) {
                 return `${parsing} second`;
             } else {
-                return `${numberWithCommas(parsing)} seconds`;
+                return `${parsing?.toLocaleString()} seconds`;
             }
         case value >= minute && value < hour:
             parsing = isFloat(value / minute) ? Math.round((value / minute + Number.EPSILON) * 100) / 100 : value / minute;
             if (parsing === 1) {
                 return `${parsing} minute`;
             } else {
-                return `${numberWithCommas(parsing)} minutes`;
+                return `${parsing?.toLocaleString()} minutes`;
             }
         case value >= hour && value < day:
             parsing = isFloat(value / hour) ? Math.round((value / hour + Number.EPSILON) * 100) / 100 : value / hour;
             if (parsing === 1) {
                 return `${parsing} hour`;
             } else {
-                return `${numberWithCommas(parsing)} hours`;
+                return `${parsing?.toLocaleString()} hours`;
             }
         case value >= day:
             parsing = isFloat(value / day) ? Math.round((value / day + Number.EPSILON) * 100) / 100 : value / day;
             if (parsing === 1) {
                 return `${parsing} day`;
             } else {
-                return `${numberWithCommas(parsing)} days`;
+                return `${parsing?.toLocaleString()} days`;
             }
         default:
             break;


### PR DESCRIPTION
1. Add commas to numbers of Unacked and Unprocessed messages in consumers' view in the station overview.
2. Replace the manual function numberWithCommas to toLocaleString())