### PR TITLE
Avoid `[]byte` conversion in `readMIMEHeader`

### DIFF
--- a/server/memphis_helper.go
+++ b/server/memphis_helper.go
@@ -1066,7 +1066,7 @@ func readMIMEHeader(tp *textproto.Reader) (textproto.MIMEHeader, error) {
 		}
 
 		// Process key fetching original case.
-		i := bytes.IndexByte([]byte(kv), ':')
+		i := strings.IndexByte(kv, ':')
 		if i < 0 {
 			return nil, ErrBadHeader
 		}


### PR DESCRIPTION
We can use `strings.IndexByte` to avoid an unnecessary `[]byte` conversion and reduce allocations.

Reference: https://pkg.go.dev/strings#IndexByte