### PR TITLE
fix: close button disabled in generate jwt modal

### DIFF
--- a/ui_src/src/domain/stationOverview/components/generateTokenModal/index.js
+++ b/ui_src/src/domain/stationOverview/components/generateTokenModal/index.js
@@ -196,7 +196,7 @@ const GenerateTokenModal = ({ host, close }) => {
                                 backgroundColorType={'purple'}
                                 fontSize="14px"
                                 fontWeight="bold"
-                                disabled={formFields.connection_token === ''}
+                                disabled={!userToken}
                                 isLoading={generateLoading}
                                 onClick={close}
                             />


### PR DESCRIPTION
The "Close" button in the "Generate JWT" modal was always disabled.
This PR addresses issue 970: https://github.com/memphisdev/memphis/issues/970

I wasn't sure if the button should never be disabled, or whether it should only be disabled if the token was not generated yet, so I went with the latter.