### PR TITLE
Bugfix: Bad df command

### DIFF
--- a/server/memphis_handlers_monitoring.go
+++ b/server/memphis_handlers_monitoring.go
@@ -1038,7 +1038,7 @@ func getDbStorageUsage() (float64, error) {
 }
 
 func getUnixStorageSize() float64 {
-	out, err := exec.Command("df", "-h", "/").Output()
+	out, err := exec.Command("df", "-h", "-P", "/").Output()
 	if err != nil {
 		serv.Errorf("getUnixStorageSize: " + err.Error())
 		return 0


### PR DESCRIPTION
If the filesystem name is to long the result of `df -h /` will end up on two lines. Which causes the following error:

```
panic: runtime error: index out of range [1] with length 1

goroutine 477 [running]:
github.com/memphisdev/memphis/server.getUnixStorageSize()
	/go/src/memphis/server/memphis_handlers_monitoring.go:1054 +0x454
github.com/memphisdev/memphis/server.MonitoringHandler.GetSystemComponents({0xc0001ced80?})
	/go/src/memphis/server/memphis_cloud.go:382 +0x9be8
github.com/memphisdev/memphis/server.MonitoringHandler.getMainOverviewDataDetails.func2()
	/go/src/memphis/server/memphis_cloud.go:1680 +0x45
created by github.com/memphisdev/memphis/server.MonitoringHandler.getMainOverviewDataDetails
	/go/src/memphis/server/memphis_cloud.go:1679 +0x2ca
```

Example:

```
/run # df -h /
Filesystem                Size      Used Available Use% Mounted on
/dev/mapper/cryptvol-root
                        446.5G    268.3G    170.7G  61% /
```

Solution for this is to force the output in POSIX output format.
```
/run # df -h -P /
Filesystem                Size      Used Available Capacity Mounted on
/dev/mapper/cryptvol-root         446.5G    268.3G    170.7G  61% /
```